### PR TITLE
Move registry point

### DIFF
--- a/src/main/java/carbonconfiglib/impl/internal/CarbonConfigHooks.java
+++ b/src/main/java/carbonconfiglib/impl/internal/CarbonConfigHooks.java
@@ -144,6 +144,34 @@ public class CarbonConfigHooks implements IFMLLoadingPlugin, IClassTransformer {
             }
         }
 
+        if ("net.minecraftforge.fml.client.FMLClientHandler".equals(transformedName)) {
+            ClassNode node = new ClassNode();
+            new ClassReader(basicClass).accept(node, 0);
+
+            for (final MethodNode method : node.methods) {
+                if (method.name.equals("finishMinecraftLoading") && method.desc.equals("()V")) {
+                    AbstractInsnNode a = method.instructions.getLast();
+
+                    while (a.getPrevious() != method.instructions.getFirst() && (a.getType() != AbstractInsnNode.INSN || a.getOpcode() != Opcodes.RETURN)) {
+                        a = a.getPrevious();
+                    }
+
+                    if (a.getOpcode() != Opcodes.RETURN)
+                        break;
+
+                    InsnList list = new InsnList();
+                    list.add(new VarInsnNode(Opcodes.ALOAD, 0));
+                    list.add(new FieldInsnNode(Opcodes.GETFIELD, "net/minecraftforge/fml/client/FMLClientHandler", "guiFactories", "Lcom/google/common/collect/BiMap;"));
+                    list.add(new MethodInsnNode(Opcodes.INVOKESTATIC, "carbonconfiglib/impl/internal/EventHandler", "registerGuiFactories", "(Lcom/google/common/collect/BiMap;)V", false));
+
+                    method.instructions.insertBefore(a, list);
+                    ClassWriter writer = new ClassWriter(0);
+                    node.accept(writer);
+                    return writer.toByteArray();
+                }
+            }
+        }
+
         return basicClass;
     }
 }

--- a/src/main/java/carbonconfiglib/impl/internal/EventHandler.java
+++ b/src/main/java/carbonconfiglib/impl/internal/EventHandler.java
@@ -15,10 +15,8 @@ import carbonconfiglib.gui.base.screen.ITickableScreen;
 import carbonconfiglib.gui.impl.carbon.ModConfigs;
 import carbonconfiglib.gui.impl.forge.ForgeConfigs;
 import carbonconfiglib.gui.impl.minecraft.MinecraftConfigs;
-import carbonconfiglib.gui.screens.ConfigListScreen;
 import carbonconfiglib.gui.screens.ConfigScreenFactory;
 import carbonconfiglib.gui.screens.ModConfigList;
-import carbonconfiglib.gui.screens.ModDependencyScreen;
 import carbonconfiglib.impl.PerWorldProxy;
 import carbonconfiglib.networking.carbon.StateSyncPacket;
 import carbonconfiglib.networking.snyc.BulkSyncPacket;
@@ -30,16 +28,12 @@ import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.integrated.IntegratedServer;
-import net.minecraftforge.client.event.GuiOpenEvent;
 import net.minecraftforge.common.config.Configuration;
-import net.minecraftforge.fml.client.FMLClientHandler;
-import net.minecraftforge.fml.client.GuiModList;
 import net.minecraftforge.fml.client.IModGuiFactory;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.IFMLSidedHandler;
 import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.ModContainer;
-import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.PlayerEvent.PlayerLoggedOutEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent.ClientTickEvent;
@@ -162,13 +156,9 @@ public class EventHandler implements IConfigChangeListener
 		}
 	}
 	
-	@SubscribeEvent
 	@SideOnly(Side.CLIENT)
-	public void onGuiOpenedEvent(GuiOpenEvent event) {
-		GuiScreen screen = event.getGui();
-		if(GuiModList.class.isInstance(screen) || ConfigListScreen.class.isInstance(screen) || ModDependencyScreen.class.isInstance(screen)) {
-			registerConfigs();
-		}
+	public static void registerGuiFactories(BiMap<ModContainer, IModGuiFactory> factory) {
+		INSTANCE.registerConfigs(factory);
 	}
 	
 	public void processIMCEvents(Map<String, ModContainer> config, Map<ModContainer, ModContainer> remapping) {
@@ -190,10 +180,9 @@ public class EventHandler implements IConfigChangeListener
 	}
 	
 	@SideOnly(Side.CLIENT)
-	private void registerConfigs() {
-		if(loaded) return;
+	private void registerConfigs(BiMap<ModContainer, IModGuiFactory> factory) {
+		if(loaded || factory == null) return;
 		loaded = true;
-		BiMap<ModContainer, IModGuiFactory> factory = ObfuscationReflectionHelper.getPrivateValue(FMLClientHandler.class, FMLClientHandler.instance(), "guiFactories");
 		Object2ObjectMap<ModContainer, List<IModConfigs>> mappedConfigs = new Object2ObjectLinkedOpenHashMap<>();
 		configs.forEach((M, C) -> {
 			if(factory.containsKey(M)) return;


### PR DESCRIPTION
This PR moves `EventHandler.registerConfigs` to a hook in `FMLClientHandler.finishMinecraftLoading`.

This solves issues with mod list redirect mods like [Catalogue Vintage](https://github.com/RuiXuqi/Catalogue-Vintage), also making the registry less dependent on user's actions and align behavior to modern MC branches.

Should not be difficult to pick this change to 1.7.10 and I am willing to help.